### PR TITLE
Feature/iteration1 toggle page view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "hang-in-there-AJ",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/src/main.js
+++ b/src/main.js
@@ -100,11 +100,15 @@ var quotes = [
 ];
 var savedPosters = [];
 var currentPoster;
-
+var mainPageImage = document.querySelector('.poster-img')
+var randomImageIndex = getRandomIndex(images)
+var actualRandomImage = images[randomImageIndex]
+console.log(actualRandomImage)
 // event listeners go here 👇
 
 // functions and event handlers go here 👇
 // (we've provided two to get you started)!
+
 function getRandomIndex(array) {
   return Math.floor(Math.random() * array.length);
 }
@@ -116,3 +120,12 @@ function createPoster(imageURL, title, quote) {
     title: title, 
     quote: quote}
 }
+mainPageImage.src = actualRandomImage
+console.log(typeof actualRandomImage)
+
+/*Goal: generate a random image onto the main page
+Take in the images array as a parameter for the function, iterate through that array,
+return a random image.
+Access the class poster image in the HTML document
+Questions - How do we specify that we're changing the poster image from the JS?
+- How do we randomize the selection?*/

--- a/src/main.js
+++ b/src/main.js
@@ -103,7 +103,10 @@ var currentPoster;
 var mainPageImage = document.querySelector('.poster-img')
 var mainPageTitle = document.querySelector('.poster-title')
 var mainPageQuote = document.querySelector('.poster-quote')
-var button = document.querySelector('.show-random')
+var buttonRandom = document.querySelector('.show-random')
+var buttonCreate = document.querySelector('.show-form')
+var posterForm = document.querySelector('.poster-form')
+
 
 var randomImageIndex = getRandomIndex(images)
 var actualRandomImage = images[randomImageIndex]
@@ -117,8 +120,8 @@ var randomQuoteIndex = getRandomIndex(quotes)
 var randomQuote = quotes[randomQuoteIndex]
 mainPageQuote.innerText = randomQuote
 // event listeners go here 👇
-button.addEventListener('click', showRandomPoster)
-
+buttonRandom.addEventListener('click', showRandomPoster)
+buttonCreate.addEventListener('click', openMakePosterPage)
 // functions and event handlers go here 👇
 // (we've provided two to get you started)!
 
@@ -148,9 +151,15 @@ function showRandomPoster() {
   mainPageQuote.innerText = randomQuote
 }
 
-/*Goal: generate a random image onto the main page
-Take in the images array as a parameter for the function, iterate through that array,
-return a random image.
-Access the class poster image in the HTML document
-Questions - How do we specify that we're changing the poster image from the JS?
-- How do we randomize the selection?*/
+function openMakePosterPage() {
+  poster-form.classList.remove('hidden')
+}
+
+/*
+Goal:
+ - Unhide poster-form hidden when the button is clicked
+
+ Code:
+  - reassign, replace, remove, the poster-form hidden class
+  - We want to reassign / replace with poster-form class
+  - Want to create a event listener for a button click and the function aboce as parameter*/

--- a/src/main.js
+++ b/src/main.js
@@ -101,10 +101,23 @@ var quotes = [
 var savedPosters = [];
 var currentPoster;
 var mainPageImage = document.querySelector('.poster-img')
+var mainPageTitle = document.querySelector('.poster-title')
+var mainPageQuote = document.querySelector('.poster-quote')
+var button = document.querySelector('.show-random')
+
 var randomImageIndex = getRandomIndex(images)
 var actualRandomImage = images[randomImageIndex]
-console.log(actualRandomImage)
+mainPageImage.src = actualRandomImage
+  
+var randomTitleIndex = getRandomIndex(titles)
+var randomTitle = titles[randomTitleIndex]
+mainPageTitle.innerText = randomTitle
+
+var randomQuoteIndex = getRandomIndex(quotes)
+var randomQuote = quotes[randomQuoteIndex]
+mainPageQuote.innerText = randomQuote
 // event listeners go here 👇
+button.addEventListener('click', showRandomPoster)
 
 // functions and event handlers go here 👇
 // (we've provided two to get you started)!
@@ -120,8 +133,20 @@ function createPoster(imageURL, title, quote) {
     title: title, 
     quote: quote}
 }
-mainPageImage.src = actualRandomImage
-console.log(typeof actualRandomImage)
+
+function showRandomPoster() {
+  var randomImageIndex = getRandomIndex(images)
+  var actualRandomImage = images[randomImageIndex]
+  mainPageImage.src = actualRandomImage
+    
+  var randomTitleIndex = getRandomIndex(titles)
+  var randomTitle = titles[randomTitleIndex]
+  mainPageTitle.innerText = randomTitle
+  
+  var randomQuoteIndex = getRandomIndex(quotes)
+  var randomQuote = quotes[randomQuoteIndex]
+  mainPageQuote.innerText = randomQuote
+}
 
 /*Goal: generate a random image onto the main page
 Take in the images array as a parameter for the function, iterate through that array,

--- a/src/main.js
+++ b/src/main.js
@@ -106,8 +106,11 @@ var mainPageQuote = document.querySelector('.poster-quote')
 var buttonRandom = document.querySelector('.show-random')
 var buttonCreate = document.querySelector('.show-form')
 var posterForm = document.querySelector('.poster-form')
-
-
+var mainPage = document.querySelector('.main-poster')
+var buttonShowMain = document.querySelector('.show-main')
+var buttonShowSaved = document.querySelector('.show-saved')
+var savedPosters = document.querySelector('.saved-posters')
+var buttonBackMain = document.querySelector('.back-to-main')
 var randomImageIndex = getRandomIndex(images)
 var actualRandomImage = images[randomImageIndex]
 mainPageImage.src = actualRandomImage
@@ -119,9 +122,15 @@ mainPageTitle.innerText = randomTitle
 var randomQuoteIndex = getRandomIndex(quotes)
 var randomQuote = quotes[randomQuoteIndex]
 mainPageQuote.innerText = randomQuote
+
 // event listeners go here 👇
 buttonRandom.addEventListener('click', showRandomPoster)
 buttonCreate.addEventListener('click', openMakePosterPage)
+
+buttonShowMain.addEventListener('click', closeMakePosterPage)
+
+buttonShowSaved.addEventListener('click', openSavedPosters)
+buttonBackMain.addEventListener('click', closeSavedPosters)
 // functions and event handlers go here 👇
 // (we've provided two to get you started)!
 
@@ -152,8 +161,25 @@ function showRandomPoster() {
 }
 
 function openMakePosterPage() {
-  poster-form.classList.remove('hidden')
+  posterForm.classList.remove('hidden')
+  mainPage.classList.add('hidden')
 }
+
+function closeMakePosterPage() {
+  posterForm.classList.add('hidden')
+  mainPage.classList.remove('hidden')
+}
+
+function openSavedPosters() {
+  savedPosters.classList.remove('hidden')
+  mainPage.classList.add('hidden')
+}
+
+function closeSavedPosters() {
+  savedPosters.classList.add('hidden')
+  mainPage.classList.remove('hidden')
+}
+
 
 /*
 Goal:
@@ -162,4 +188,10 @@ Goal:
  Code:
   - reassign, replace, remove, the poster-form hidden class
   - We want to reassign / replace with poster-form class
-  - Want to create a event listener for a button click and the function aboce as parameter*/
+  - Want to create a event listener for a button click and the function aboce as parameter
+  
+Questions:
+ - how do we remove just the hidden class
+ - Poster from 'poster-form' line 155 is unideftified -- wtf
+  
+  */


### PR DESCRIPTION
- [x] When a user clicks the “Make Your Own Poster” button, we should see the form, and the main poster should be hidden
- [x] When a user clicks the “View Saved Posters” button, we should see the saved posters area, and the main poster should be hidden
- [x] When a user clicks the “Nevermind, take me back!” or “Back to Main” buttons, we should only see the main poster section
- [x] In summary: Be able to switch between the three views (main poster, form, and saved posters) on the correct button clicks